### PR TITLE
Property setter

### DIFF
--- a/rstcloth/cloth.py
+++ b/rstcloth/cloth.py
@@ -54,5 +54,9 @@ class Cloth(object):
         return self._data
 
     @data.setter
-    def data(self):
-        raise AttributeError('cannot set the RstCloth.data attribute directly')
+    def data(self, value):
+        raise AttributeError(
+            'cannot set the {}.data attribute directly'.format(
+                self.__class__.__name__
+            )
+        )

--- a/rstcloth/cloth.py
+++ b/rstcloth/cloth.py
@@ -19,6 +19,9 @@ logger = logging.getLogger("rstcloth.cloth")
 
 
 class Cloth(object):
+    def __init__(self):
+        self._data = []
+
     def print_content(self, block_order=None):
         if block_order is not None:
             logger.warning('block_order "{0}" is no longer supported'.format(block_order))

--- a/rstcloth/rstcloth.py
+++ b/rstcloth/rstcloth.py
@@ -60,9 +60,6 @@ def _indent(content, indent):
 
 
 class RstCloth(Cloth):
-    def __init__(self):
-        self._data = []
-
     def _add(self, content, block=None):
         if block is not None:
             logger.warning('block "{0}" is no longer supported'.format(block))

--- a/test/test_rstcloth.py
+++ b/test/test_rstcloth.py
@@ -346,3 +346,9 @@ class TestRstCloth(TestCase):
     def test_ref_target_unnamed_wo_indent(self):
         self.r.ref_target("foo-are-magic-ref3", 3, block='ref3')
         self.assertEqual(self.r.data, ['   .. _foo-are-magic-ref3:'])
+
+    def test_set_data(self):
+        with self.assertRaises(AttributeError) as exception:
+            self.r.data = []
+        self.assertIn('cannot set the RstCloth.data attribute directly',
+                      exception.exception.args)


### PR DESCRIPTION
Hi,

Please consider following example:
```python
import rstcloth.rstcloth
>>> document = rstcloth.rstcloth.RstCloth()
>>> document.data = []
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: data() takes 1 positional argument but 2 were given
```
So I believe there is an error in: https://github.com/cyborginstitute/rstcloth/blob/da18c5218bbdd00472b09dddda07e390cf786795/rstcloth/cloth.py#L53-L55

This merge request aims to fix this issue.