### PR TITLE
Python3 support improved.

### DIFF
--- a/rstcloth/table.py
+++ b/rstcloth/table.py
@@ -18,7 +18,6 @@ from __future__ import unicode_literals
 import os
 import logging
 import argparse
-import string
 import textwrap
 
 import yaml
@@ -425,7 +424,7 @@ class HtmlTable(OutputTable):
         return ''.join(row)
 
     def _get_ending_tag(self, tag):
-        return string.join(tag.split('<', 1), '</')
+        return tag.replace('<', '</', 1)
 
 
 class TableBuilder(object):

--- a/test/test_table.py
+++ b/test/test_table.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+from rstcloth.table import HtmlTable, TableData
+
+
+class TestHtmlTable(TestCase):
+    @classmethod
+    def setUp(cls):
+        table_data = TableData()
+        table_data.add_row(row=['a', 'b', 'c'])
+        cls.table = HtmlTable(imported_table=table_data)
+
+    def test_get_ending_tag(self):
+        given = '<foo>'
+        expected = '</foo>'
+        self.assertEqual(expected, self.table._get_ending_tag(given))
+
+    def test_get_ending_tag_from_plain_string(self):
+        given = expected = 'foo'
+        self.assertEqual(expected, self.table._get_ending_tag(given))
+
+    def test_get_ending_tag_double_brackets(self):
+        given = '<foo><bar>'
+        expected = '</foo><bar>'
+        self.assertEqual(expected, self.table._get_ending_tag(given))


### PR DESCRIPTION
In python3 `string` module has no `join` function. Same logic is achieved using python version agnostic instructions. Also a few tests were added to confirm it.