### PR TITLE
get over obsolescences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ python:
   - 'pypy3'
 install:
   - pip install .
-  - pip install pyflakes pep8
+  - if [[ $TRAVIS_PYTHON_VERSION = '3.3' ]]; then pip install 'pyflakes<2.0.0'; fi
+  - pip install nose pycodestyle pyflakes
 script: make test
 notifications:
   flowdock:

--- a/makefile
+++ b/makefile
@@ -18,12 +18,14 @@ pyflakes:
 	@echo "[testing] running pyflakes:"
 	pyflakes rstcloth
 
-pep8:
-	@echo "[testing] running pep8: "
-	pep8 --max-line-length=100 rstcloth
+pycodestyle:
+	@echo "[testing] running pycodestyle: "
+	pycodestyle --max-line-length=100 rstcloth
 
 
-test: nosetests pyflakes pep8
+test: nosetests pyflakes pycodestyle
+
+pep8: pycodestyle
 
 push-git:
 	git push cyborg

--- a/rstcloth/cloth.py
+++ b/rstcloth/cloth.py
@@ -19,16 +19,10 @@ logger = logging.getLogger("rstcloth.cloth")
 
 
 class Cloth(object):
-    def print_content(self, block_order=None):
-        if block_order is not None:
-            logger.warning('block_order "{0}" is no longer supported'.format(block_order))
-
+    def print_content(self):
         print('\n'.join(self._data))
 
-    def write(self, filename, block_order=None):
-        if block_order is not None:
-            logger.warning('block_order "{0}" is no longer supported'.format(block_order))
-
+    def write(self, filename):
         dirpath = os.path.dirname(filename)
         if os.path.isdir(dirpath) is False:
             try:

--- a/rstcloth/cloth.py
+++ b/rstcloth/cloth.py
@@ -25,9 +25,6 @@ class Cloth(object):
 
         print('\n'.join(self._data))
 
-    def print_block(self, block='_all'):
-        logger.warning('print_block is no longer supported')
-
     def write(self, filename, block_order=None):
         if block_order is not None:
             logger.warning('block_order "{0}" is no longer supported'.format(block_order))
@@ -42,9 +39,6 @@ class Cloth(object):
         with open(filename, 'w') as f:
             f.write('\n'.join(self._data))
             f.write('\n')
-
-    def write_block(self, filename, block='_all'):
-        logger.warning('write_block is no longer supported')
 
     @property
     def data(self):

--- a/rstcloth/rstcloth.py
+++ b/rstcloth/rstcloth.py
@@ -63,16 +63,13 @@ class RstCloth(Cloth):
     def __init__(self):
         self._data = []
 
-    def _add(self, content, block=None):
-        if block is not None:
-            logger.warning('block "{0}" is no longer supported'.format(block))
-
+    def _add(self, content):
         if isinstance(content, list):
             self._data.extend(content)
         else:
             self._data.append(content)
 
-    def newline(self, count=1, block=None):
+    def newline(self, count=1):
         if isinstance(count, int):
             if count == 1:
                 self._add('')
@@ -82,7 +79,7 @@ class RstCloth(Cloth):
         else:
             raise Exception("Count of newlines must be a positive int.")
 
-    def directive(self, name, arg=None, fields=None, content=None, indent=0, wrap=True, block=None):
+    def directive(self, name, arg=None, fields=None, content=None, indent=0, wrap=True):
         o = []
 
         o.append('.. {0}::'.format(name))
@@ -138,21 +135,21 @@ class RstCloth(Cloth):
     def _paragraph(content, wrap=True):
         return [i.rstrip() for i in fill(content, wrap=wrap).split('\n')]
 
-    def replacement(self, name, value, indent=0, block=None):
+    def replacement(self, name, value, indent=0):
         output = '.. |{0}| replace:: {1}'.format(name, value)
         self._add(_indent(output, indent))
 
-    def codeblock(self, content, indent=0, wrap=True, language=None, block=None):
+    def codeblock(self, content, indent=0, wrap=True, language=None):
         if language is None:
             o = ['::', _indent(content, 3)]
             self._add(_indent(o, indent))
         else:
             self.directive(name='code-block', arg=language, content=content, indent=indent)
 
-    def footnote(self, ref, text, indent=0, wrap=True, block=None):
+    def footnote(self, ref, text, indent=0, wrap=True):
         self._add(fill('.. [#{0}] {1}'.format(ref, text), indent, indent + 3, wrap))
 
-    def definition(self, name, text, indent=0, wrap=True, bold=False, block=None):
+    def definition(self, name, text, indent=0, wrap=True, bold=False):
         o = []
 
         if bold is True:
@@ -163,7 +160,7 @@ class RstCloth(Cloth):
 
         self._add(o)
 
-    def li(self, content, bullet='-', indent=0, wrap=True, block=None):
+    def li(self, content, bullet='-', indent=0, wrap=True):
         bullet = bullet + ' '
         hanging_indent_len = indent + len(bullet)
 
@@ -174,7 +171,7 @@ class RstCloth(Cloth):
             content = bullet + fill(content, 0, len(bullet), wrap)
             self._add(fill(content, indent, indent, wrap))
 
-    def field(self, name, value, indent=0, wrap=True, block=None):
+    def field(self, name, value, indent=0, wrap=True):
         output = [':{0}:'.format(name)]
 
         if len(name) + len(value) < 60:
@@ -195,11 +192,11 @@ class RstCloth(Cloth):
         for line in output:
             self._add(_indent(line, indent))
 
-    def ref_target(self, name, indent=0, block=None):
+    def ref_target(self, name, indent=0):
         o = '.. _{0}:'.format(name)
         self._add(_indent(o, indent))
 
-    def content(self, content, indent=0, wrap=True, block=None):
+    def content(self, content, indent=0, wrap=True):
         if isinstance(content, list):
             for line in content:
                 self._add(_indent(line, indent))
@@ -209,27 +206,27 @@ class RstCloth(Cloth):
             for line in lines:
                 self._add(_indent(line, indent))
 
-    def title(self, text, char='=', indent=0, block=None):
+    def title(self, text, char='=', indent=0):
         line = char * len(text)
         self._add(_indent([line, text, line], indent))
 
-    def heading(self, text, char, indent=0, block=None):
+    def heading(self, text, char, indent=0):
         self._add(_indent([text, char * len(text)], indent))
 
-    def h1(self, text, indent=0, block=None):
+    def h1(self, text, indent=0):
         self.heading(text, char='=', indent=indent)
 
-    def h2(self, text, indent=0, block=None):
+    def h2(self, text, indent=0):
         self.heading(text, char='-', indent=indent)
 
-    def h3(self, text, indent=0, block=None):
+    def h3(self, text, indent=0):
         self.heading(text, char='~', indent=indent)
 
-    def h4(self, text, indent=0, block=None):
+    def h4(self, text, indent=0):
         self.heading(text, char='+', indent=indent)
 
-    def h5(self, text, indent=0, block=None):
+    def h5(self, text, indent=0):
         self.heading(text, char='^', indent=indent)
 
-    def h6(self, text, indent=0, block=None):
+    def h6(self, text, indent=0):
         self.heading(text, char=';', indent=indent)

--- a/rstcloth/table.py
+++ b/rstcloth/table.py
@@ -19,14 +19,10 @@ import os
 import logging
 import argparse
 import string
-import textwrap
 
 import yaml
 
-try:
-    from rstcloth import RstCloth
-except ImportError:
-    from rstcloth.rstcloth import RstCloth
+from .rstcloth import RstCloth
 
 logger = logging.getLogger('rstcloth.table')
 
@@ -451,6 +447,7 @@ def get_outputfile(inputfile, outputfile):
     else:
         return outputfile
 
+
 formats = {'rst': RstTable,
            'list': ListTable,
            'html': HtmlTable}
@@ -479,6 +476,7 @@ def main():
     table = TableBuilder(formats[table_data.format](table_data))
 
     table.write(get_outputfile(ui.input, ui.output))
+
 
 if __name__ == '__main__':
     main()

--- a/rstcloth/table.py
+++ b/rstcloth/table.py
@@ -336,8 +336,6 @@ class ListTable(OutputTable):
         self.output = self.r.data
 
     def _render_table(self):
-        b = '_all'
-
         rows = []
         _fields = []
         if self.table.header is not None:
@@ -352,19 +350,19 @@ class ListTable(OutputTable):
 
         rows.extend(self.table.rows)
 
-        self.r.directive('list-table', fields=_fields, indent=self.indent, block=b)
+        self.r.directive('list-table', fields=_fields, indent=self.indent)
 
-        self.r.newline(block=b)
+        self.r.newline()
 
         for row in rows:
             r = row[idx]
 
-            self.r.li(r[0], bullet='* -', indent=self.indent + 3, wrap=False, block=b)
-            self.r.newline(block=b)
+            self.r.li(r[0], bullet='* -', indent=self.indent + 3, wrap=False)
+            self.r.newline()
 
             for cell in r[1:]:
-                self.r.li(cell, bullet='  -',  indent=self.indent + 3, wrap=False, block=b)
-                self.r.newline(block=b)
+                self.r.li(cell, bullet='  -',  indent=self.indent + 3, wrap=False)
+                self.r.newline()
 
             idx += 1
 

--- a/rstcloth/table.py
+++ b/rstcloth/table.py
@@ -45,15 +45,6 @@ def normalize_cell_height(rowdata):
             cell.append(' ')
 
 
-def fill(string, first=0, hanging=0):
-    first_indent = ' ' * first
-    hanging_indent = ' ' * hanging
-
-    return textwrap.fill(string,
-                         width=72,
-                         initial_indent=first_indent,
-                         subsequent_indent=hanging_indent)
-
 ###################################
 #
 # Generating parts of the table.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,9 @@ setup(
     license='Apache',
     url='http://cyborginstitute.org/projects/rstcloth',
     packages=['rstcloth'],
-    setup_requires=['nose'],
+    install_requires=[
+        'PyYAML'
+    ],
     test_suite='test',
     classifiers=[
         'Programming Language :: Python',

--- a/test/test_rstcloth.py
+++ b/test/test_rstcloth.py
@@ -19,47 +19,47 @@ class TestRstCloth(TestCase):
         self.assertEqual(len(self.r.data[0]), 4 - 1)
 
     def test_directive_simple(self):
-        self.r.directive('test', block='d0')
+        self.r.directive('test')
         self.assertEqual(self.r.data[0], '.. test::')
 
     def test_directive_arg_named(self):
-        self.r.directive('test', arg='what', block='d3')
+        self.r.directive('test', arg='what')
         self.assertEqual(self.r.data[0], '.. test:: what')
 
     def test_directive_arg_positional(self):
-        self.r.directive('test', 'what', block='d1')
+        self.r.directive('test', 'what')
         self.assertEqual(self.r.data[0], '.. test:: what')
 
     def test_directive_fields(self):
-        self.r.directive('test', fields=[('a', 'b')], block='d2')
+        self.r.directive('test', fields=[('a', 'b')])
         self.assertEqual(self.r.data[0], '.. test::')
         self.assertEqual(self.r.data[1], '   :a: b')
 
     def test_directive_fields_with_arg(self):
-        self.r.directive('test', arg='what', fields=[('a', 'b')], block='d4')
+        self.r.directive('test', arg='what', fields=[('a', 'b')])
         self.assertEqual(self.r.data[0], '.. test:: what')
         self.assertEqual(self.r.data[1], '   :a: b')
 
     def test_directive_fields_multiple(self):
-        self.r.directive('test', fields=[('a', 'b'), ('c', 'd')], block='d5')
+        self.r.directive('test', fields=[('a', 'b'), ('c', 'd')])
         self.assertEqual(self.r.data[0], '.. test::')
         self.assertEqual(self.r.data[1], '   :a: b')
         self.assertEqual(self.r.data[2], '   :c: d')
 
     def test_directive_fields_multiple_arg(self):
-        self.r.directive('test', arg='new', fields=[('a', 'b'), ('c', 'd')], block='d6')
+        self.r.directive('test', arg='new', fields=[('a', 'b'), ('c', 'd')])
         self.assertEqual(self.r.data[0], '.. test:: new')
         self.assertEqual(self.r.data[1], '   :a: b')
         self.assertEqual(self.r.data[2], '   :c: d')
 
     def test_directive_content(self):
-        self.r.directive('test', content='string', block='d7')
+        self.r.directive('test', content='string')
         self.assertEqual(self.r.data[0], '.. test::')
         self.assertEqual(self.r.data[1], '')
         self.assertEqual(self.r.data[2], '   string')
 
     def test_directive_with_multiline_content(self):
-        self.r.directive('test', content=['string', 'second'], block='d8')
+        self.r.directive('test', content=['string', 'second'])
         self.assertEqual(self.r.data[0], '.. test::')
         self.assertEqual(self.r.data[1], '')
         self.assertEqual(self.r.data[2], '   string')
@@ -67,39 +67,39 @@ class TestRstCloth(TestCase):
 
 
     def test_directive_simple_indent(self):
-        self.r.directive('test', indent=3, block='di0')
+        self.r.directive('test', indent=3)
         self.assertEqual(self.r.data, ['   .. test::'])
 
     def test_directive_arg_named_indent(self):
-        self.r.directive('test', arg='what', indent=3, block='di3')
+        self.r.directive('test', arg='what', indent=3)
         self.assertEqual(self.r.data, ['   .. test:: what'])
 
     def test_directive_arg_positional_indent(self):
-        self.r.directive('test', 'what', indent=3, block='di1')
+        self.r.directive('test', 'what', indent=3)
         self.assertEqual(self.r.data, ['   .. test:: what'])
 
     def test_directive_fields_indent(self):
-        self.r.directive('test', fields=[('a', 'b')], indent=3, block='di2')
+        self.r.directive('test', fields=[('a', 'b')], indent=3)
         self.assertEqual(self.r.data, ['   .. test::', '      :a: b'])
 
     def test_directive_fields_with_arg_indent(self):
-        self.r.directive('test', arg='what', fields=[('a', 'b')], indent=3, block='di4')
+        self.r.directive('test', arg='what', fields=[('a', 'b')], indent=3)
         self.assertEqual(self.r.data, ['   .. test:: what', '      :a: b'])
 
     def test_directive_fields_multiple_indent(self):
-        self.r.directive('test', indent=3, fields=[('a', 'b'), ('c', 'd')], block='di5')
+        self.r.directive('test', indent=3, fields=[('a', 'b'), ('c', 'd')])
         self.assertEqual(self.r.data, ['   .. test::', '      :a: b', '      :c: d'])
 
     def test_directive_fields_multiple_arg_indent(self):
-        self.r.directive('test', arg='new', indent=3, fields=[('a', 'b'), ('c', 'd')], block='di6')
+        self.r.directive('test', arg='new', indent=3, fields=[('a', 'b'), ('c', 'd')])
         self.assertEqual(self.r.data, ['   .. test:: new', '      :a: b', '      :c: d'])
 
     def test_directive_content_indent(self):
-        self.r.directive('test', content='string', indent=3, block='di7')
+        self.r.directive('test', content='string', indent=3)
         self.assertEqual(self.r.data, ['   .. test::', '   ', '      string'])
 
     def test_directive_with_multiline_content_indent(self):
-        self.r.directive('test', indent=3, content=['string', 'second'], block='di8')
+        self.r.directive('test', indent=3, content=['string', 'second'])
         self.assertEqual(self.r.data, ['   .. test::', '   ', '      string', '      second'])
 
     def test_single_role_no_text(self):
@@ -155,194 +155,194 @@ class TestRstCloth(TestCase):
         self.assertEqual(ret, '[#name]')
 
     def test_codeblock_simple(self):
-        self.r.codeblock('ls -lha', block='cb0')
+        self.r.codeblock('ls -lha')
         self.assertEqual(self.r.data, ['::', '   ls -lha'])
 
     def test_codeblock_with_language(self):
-        self.r.codeblock('ls -lha', language='shell',block='cb1')
+        self.r.codeblock('ls -lha', language='shell')
         self.assertEqual(self.r.data, ['.. code-block:: shell', '', '   ls -lha'])
 
     def test_footnote(self):
-        self.r.footnote('footsnotes', 'text of the note', block='fn0')
+        self.r.footnote('footsnotes', 'text of the note')
         self.assertEqual(self.r.data[0], '.. [#footsnotes] text of the note')
 
     def test_footnote_with_indent(self):
-        self.r.footnote('footsnotes', 'text of the note', block='fn1', indent=3)
+        self.r.footnote('footsnotes', 'text of the note', indent=3)
         self.assertEqual(self.r.data[0], '   .. [#footsnotes] text of the note')
 
     def test_footnote_with_wrap(self):
-        self.r.footnote('footsnotes', 'the ' * 40, block='fn2', wrap=True)
+        self.r.footnote('footsnotes', 'the ' * 40, wrap=True)
         self.assertEqual(self.r.data[0],
                          '.. [#footsnotes]' + ' the' * 14 + '\n  ' + ' the' * 17 + '\n  ' + ' the' * 9)
 
     def test_definition(self):
-        self.r.definition('defitem', 'this is def text', block='dfn0')
+        self.r.definition('defitem', 'this is def text')
         self.assertEqual(self.r.data, ['defitem', '   this is def text'])
 
     def test_definition_with_indent(self):
-        self.r.definition('defitem', 'this is def text', indent=3, block='dfn1')
+        self.r.definition('defitem', 'this is def text', indent=3)
         self.assertEqual(self.r.data, ['   defitem', '      this is def text'])
 
     def test_title_default(self):
-        self.r.title('test text', block='hd0')
+        self.r.title('test text')
         self.assertEqual(self.r.data, ['=========', 'test text', '========='])
 
     def test_title_alt(self):
-        self.r.title('test text', char='-', block='hd1')
+        self.r.title('test text', char='-')
         self.assertEqual(self.r.data, ['---------', 'test text', '---------'])
 
     def test_heading_one(self):
-        self.r.heading('test heading', char='-', indent=0, block='hd2')
+        self.r.heading('test heading', char='-', indent=0)
         self.assertEqual(self.r.data, ['test heading', '------------'])
 
     def test_heading_two(self):
-        self.r.heading('test heading', char='^', indent=0, block='hd3')
+        self.r.heading('test heading', char='^', indent=0)
         self.assertEqual(self.r.data, ['test heading', '^^^^^^^^^^^^'])
 
     def test_h1(self):
-        self.r.h1('test', block='hd4')
+        self.r.h1('test')
         self.assertEqual(self.r.data, ['test', '===='])
 
     def test_h2(self):
-        self.r.h2('test', block='hd5')
+        self.r.h2('test')
         self.assertEqual(self.r.data, ['test', '----'])
 
     def test_h3(self):
-        self.r.h3('test', block='hd6')
+        self.r.h3('test')
         self.assertEqual(self.r.data, ['test', '~~~~'])
 
     def test_h4(self):
-        self.r.h4('test', block='hd7')
+        self.r.h4('test')
         self.assertEqual(self.r.data, ['test', '++++'])
 
     def test_h5(self):
-        self.r.h5('test', block='hd8')
+        self.r.h5('test')
         self.assertEqual(self.r.data, ['test', '^^^^'])
 
     def test_h6(self):
-        self.r.h6('test', block='hd9')
+        self.r.h6('test')
         self.assertEqual(self.r.data, ['test', ';;;;'])
 
     def test_replacement(self):
-        self.r.replacement('foo', 'replace-with-bar', block='sub0')
+        self.r.replacement('foo', 'replace-with-bar')
         self.assertEqual(self.r.data, ['.. |foo| replace:: replace-with-bar'])
 
     def test_replacement_with_indent(self):
-        self.r.replacement('foo', 'replace-with-bar', indent=3, block='sub1')
+        self.r.replacement('foo', 'replace-with-bar', indent=3)
         self.assertEqual(self.r.data, ['   .. |foo| replace:: replace-with-bar'])
 
     def test_li_simple(self):
-        self.r.li('foo', block='li0')
+        self.r.li('foo')
         self.assertEqual(self.r.data, ['- foo'])
 
     def test_li_simple_indent(self):
-        self.r.li('foo', indent=3, block='li1')
+        self.r.li('foo', indent=3)
         self.assertEqual(self.r.data, ['   - foo'])
 
     def test_li_simple_alt(self):
-        self.r.li('foo', bullet='*', block='li2')
+        self.r.li('foo', bullet='*')
         self.assertEqual(self.r.data, ['* foo'])
 
     def test_li_simple_alt_indent(self):
-        self.r.li('foo', bullet='*', indent=3, block='li3')
+        self.r.li('foo', bullet='*', indent=3)
         self.assertEqual(self.r.data, ['   * foo'])
 
     def test_li_complex(self):
-        self.r.li(['foo', 'bar'], block='li0')
+        self.r.li(['foo', 'bar'])
         self.assertEqual(self.r.data, ['- foo bar'])
 
     def test_li_complex_indent(self):
-        self.r.li(['foo', 'bar'], indent=3, block='li1')
+        self.r.li(['foo', 'bar'], indent=3)
         self.assertEqual(self.r.data, ['   - foo bar'])
 
     def test_li_complex_alt(self):
-        self.r.li(['foo', 'bar'], bullet='*', block='li2')
+        self.r.li(['foo', 'bar'], bullet='*')
         self.assertEqual(self.r.data, ['* foo bar'])
 
     def test_li_complex_alt_indent(self):
-        self.r.li(['foo', 'bar'], bullet='*', indent=3, block='li3')
+        self.r.li(['foo', 'bar'], bullet='*', indent=3)
         self.assertEqual(self.r.data, ['   * foo bar'])
 
     def test_field_simple(self):
-        self.r.field('fname', 'fvalue', block='fld0')
+        self.r.field('fname', 'fvalue')
         self.assertEqual(self.r.data, [':fname: fvalue'])
 
     def test_field_long_simple(self):
-        self.r.field('fname is fname', 'fvalue', block='fld1')
+        self.r.field('fname is fname', 'fvalue')
         self.assertEqual(self.r.data, [':fname is fname: fvalue'])
 
     def test_field_simple_long(self):
-        self.r.field('fname', 'v' * 54, block='fld2')
+        self.r.field('fname', 'v' * 54)
         self.assertEqual(self.r.data, [':fname: ' + 'v' * 54])
 
     def test_field_simple_long_long(self):
-        self.r.field('fname', 'v' * 55, block='fld3')
+        self.r.field('fname', 'v' * 55)
         self.assertEqual(self.r.data, [':fname:', '', '   ' + 'v' * 55])
 
     def test_field_indent_simple(self):
-        self.r.field('fname', 'fvalue', indent=3, block='fld4')
+        self.r.field('fname', 'fvalue', indent=3)
         self.assertEqual(self.r.data, ['   :fname: fvalue'])
 
     def test_field_indent_long_simple(self):
-        self.r.field('fname is fname', 'fvalue', indent=3, block='fld5')
+        self.r.field('fname is fname', 'fvalue', indent=3)
         self.assertEqual(self.r.data, ['   :fname is fname: fvalue'])
 
     def test_field_indent_simple_long(self):
-        self.r.field('fname', 'v' * 54, indent=3, block='fld6')
+        self.r.field('fname', 'v' * 54, indent=3)
         self.assertEqual(self.r.data, ['   :fname: ' + 'v' * 54])
 
     def test_field_indent_simple_long_long(self):
-        self.r.field('fname', 'v' * 55, indent=3, block='fld7')
+        self.r.field('fname', 'v' * 55, indent=3)
         self.assertEqual(self.r.data, ['   :fname:', '   ', '      ' + 'v' * 55])
 
     def test_field_wrap_simple(self):
-        self.r.field('fname', 'the ' * 100, block='fld8')
+        self.r.field('fname', 'the ' * 100)
         self.assertEqual(self.r.data, [':fname:', '', '  ' + ' the' * 18, '  ' + ' the' * 18, '  ' + ' the' * 18, '  ' + ' the' * 18, '  ' + ' the' * 18, '  ' + ' the' * 10])
 
     def test_field_wrap_indent_simple(self):
-        self.r.field('fname', 'the ' * 100, indent=3, block='fld8')
+        self.r.field('fname', 'the ' * 100, indent=3)
         self.assertEqual(self.r.data, ['   :fname:', '   ', '     ' + ' the' * 18, '     ' + ' the' * 18, '     ' + ' the' * 18, '     ' + ' the' * 18, '     ' + ' the' * 18, '     ' + ' the' * 10])
 
     def test_content_string(self):
-        self.r.content('this is sparta', block='ct0')
+        self.r.content('this is sparta')
         self.assertEqual(self.r.data, ['this is sparta'])
 
     def test_content_list(self):
-        self.r.content(['this is sparta', 'this is spinal tap'], block='ct1')
+        self.r.content(['this is sparta', 'this is spinal tap'])
         self.assertEqual(self.r.data, ['this is sparta', 'this is spinal tap'])
 
     def test_content_indent_string(self):
-        self.r.content('this is sparta', indent=3, block='ct2')
+        self.r.content('this is sparta', indent=3)
         self.assertEqual(self.r.data, ['   this is sparta'])
 
     def test_content_indent_list(self):
-        self.r.content(['this is sparta', 'this is spinal tap'], indent=3, block='ct3')
+        self.r.content(['this is sparta', 'this is spinal tap'], indent=3)
         self.assertEqual(self.r.data, ['   this is sparta', '   this is spinal tap'])
 
     def test_content_long(self):
-        self.r.content('the ' * 100, block='ct4')
+        self.r.content('the ' * 100)
         self.assertEqual(self.r.data, [ 'the' + ' the' * 17, 'the ' * 17 + 'the', 'the ' * 17 + 'the', 'the ' * 17 + 'the', 'the ' * 17 + 'the', 'the ' * 9 + 'the' ])
 
     def test_ontent_indent_long(self):
-        self.r.content('the ' * 100, indent=3 ,block='ct5')
+        self.r.content('the ' * 100, indent=3)
         self.assertEqual(self.r.data, [ '   the' + ' the' * 17, "   " + 'the ' * 17 + 'the', '   ' + 'the ' * 17 + 'the', '   ' + 'the ' * 17 + 'the', '   ' + 'the ' * 17 + 'the', '   ' + 'the ' * 9 + 'the' ])
 
     def test_ontent_indent_long_nowrap(self):
-        self.r.content('the ' * 100, wrap=False, indent=3 ,block='ct5')
+        self.r.content('the ' * 100, wrap=False, indent=3)
         self.assertEqual(self.r.data, [ '   ' + 'the ' * 99 + 'the'])
 
     def test_ref_target_named(self):
-        self.r.ref_target(name="foo-are-magic-ref0", block='ref0')
+        self.r.ref_target(name="foo-are-magic-ref0")
         self.assertEqual(self.r.data, ['.. _foo-are-magic-ref0:'])
 
     def test_ref_target_unnamed(self):
-        self.r.ref_target("foo-are-magic-ref1", block='ref1')
+        self.r.ref_target("foo-are-magic-ref1")
         self.assertEqual(self.r.data, ['.. _foo-are-magic-ref1:'])
 
     def test_ref_target_named_with_indent(self):
-        self.r.ref_target(name="foo-are-magic-ref2", indent=3, block='ref2')
+        self.r.ref_target(name="foo-are-magic-ref2", indent=3)
         self.assertEqual(self.r.data, ['   .. _foo-are-magic-ref2:'])
 
     def test_ref_target_unnamed_wo_indent(self):
-        self.r.ref_target("foo-are-magic-ref3", 3, block='ref3')
+        self.r.ref_target("foo-are-magic-ref3", 3)
         self.assertEqual(self.r.data, ['   .. _foo-are-magic-ref3:'])


### PR DESCRIPTION
This PR is aimed to get over obsolescences in this project and its dependencies with a few dependencies fixes.

1. `pep8` project was renamed to `pycodestyle` (see PyCQA/pycodestyle/issues/466)
2. `pyflakes` has dropped *python 3.3* support in version *2.0.0* (see PyCQA/pyflakes/pull/322)
3. missing `PyYAML` dependency included in `setup.py` script
4. unused `textwrap` import removed
5. global import pattern with `try`/`catch` clause replaced with python agnostic single local import
6. missing empty lines added to satisfy PEP8 guidelines (see https://www.python.org/dev/peps/pep-0008/?#blank-lines)
7. `nose` does not need to be present in order for the `setup.py` script to run (https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords)
8. `makefile` targets were updated but backward compatibility is maintained
9. unsupported `rstcloth.cloth.Cloth.print_block` and `rstcloth.cloth.Cloth.write_block` methods and unused `rstcloth.table.fill` function were removed
10. unsupported `block` and `block_order` parameters were removed