### PR TITLE
replace print_content and print_table methods with str method

### DIFF
--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -22,7 +22,7 @@ The following RstCloth code: ::
    d.h2('Code -- shebang')
    d.codeblock('#!/usr/bin/env')
 
-   d.print_content()
+   print(str(d))
 
 Would result in the following reStructuredText: ::
 
@@ -61,5 +61,22 @@ Example 2
         ]
     )
 
-    doc.print_content()
+    print(str(doc))
+
+Would result in the following reStructuredText: ::
+
+    ================
+    Example Document
+    ================
+
+
+    +-----------+-----------+-----------+
+    |Column 1   |Column 2   |Column 3   |
+    +===========+===========+===========+
+    |1          |2          |3          |
+    +-----------+-----------+-----------+
+    |4          |5          |6          |
+    +-----------+-----------+-----------+
+    |7          |8          |9          |
+    +-----------+-----------+-----------+
 

--- a/rstcloth/cloth.py
+++ b/rstcloth/cloth.py
@@ -6,8 +6,8 @@ logger = logging.getLogger("rstcloth.cloth")
 
 
 class Cloth(object):
-    def print_content(self):
-        print("\n".join(self._data))  # noqa: T001
+    def __str__(self):
+        return "\n".join(self._data)
 
     def write(self, filename):
         """

--- a/rstcloth/table.py
+++ b/rstcloth/table.py
@@ -414,8 +414,7 @@ class TableBuilder(object):
                 f.write(line + "\n")
 
     def __str__(self):
-        for line in self.output:
-            print(line)
+        return "\n".join(self.output)
 
 
 ###################################

--- a/rstcloth/table.py
+++ b/rstcloth/table.py
@@ -413,9 +413,9 @@ class TableBuilder(object):
             for line in self.output:
                 f.write(line + "\n")
 
-    def print_table(self):
+    def __str__(self):
         for line in self.output:
-            print(line)  # noqa: T001
+            print(line)
 
 
 ###################################


### PR DESCRIPTION
First of all kudos for this projects.

The purpose of this PR is to replace `rstcloth.cloth.Cloth.print_content` and `rstcloth.table.TableBuilder.print_table` with `__str__`. This PR aims to resolve #12 . Documentation has been updated accordingly.