### PR TITLE
improved tables with tabulate and list-table support

### DIFF
--- a/rstcloth/rstcloth.py
+++ b/rstcloth/rstcloth.py
@@ -122,6 +122,26 @@ class RstCloth(Cloth):
         )
         self._add(_indent("\n" + t + "\n", indent))
 
+    def table_list(self, headers, data, widths=None, indent=0):
+        _fields = []
+        rows = []
+        if headers:
+            _fields.append(("header-rows", "1"))
+            rows.extend([headers])
+        if widths is not None:
+            _fields.append(("widths", " ".join(widths)))
+
+        self.directive("list-table", fields=_fields, indent=indent)
+        self.newline()
+
+        if data:
+            rows.extend(data)
+        for row in rows:
+            self.li(row[0], bullet="* -", indent=indent + 3)
+            for cell in row[1:]:
+                self.li(cell, bullet="  -", indent=indent + 3)
+        self.newline()
+
     def directive(self, name, arg=None, fields=None, content=None, indent=0, wrap=True):
         """
 

--- a/rstcloth/rstcloth.py
+++ b/rstcloth/rstcloth.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import textwrap
+from tabulate import tabulate
 
 from rstcloth.cloth import Cloth
 
@@ -113,8 +114,13 @@ class RstCloth(Cloth):
         :return:
         """
 
-        t = Table(header, data=data)
-        self._add(_indent("\n" + t.render(), indent))
+        t = tabulate(
+            tabular_data=data,
+            headers=header,
+            tablefmt="grid",
+            disable_numparse=True
+        )
+        self._add(_indent("\n" + t + "\n", indent))
 
     def directive(self, name, arg=None, fields=None, content=None, indent=0, wrap=True):
         """

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Operating System :: OS Independent",
         "Natural Language :: English",
         "Topic :: Documentation :: Sphinx",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     long_description=readme_text,
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=("tests", "docs")),
-    install_requires=["sphinx>=2,<4", "pygments", "PyYAML"],
+    install_requires=["sphinx>=2,<4", "pygments", "PyYAML", "tabulate"],
     include_package_data=True,
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/test_rstcloth.py
+++ b/tests/test_rstcloth.py
@@ -456,6 +456,28 @@ class TestTable(unittest.TestCase):
         given = r.data[0]
         self.assertEqual(expected, given)
 
+    def test_table_list(self):
+        r = RstCloth()
+        headers = ['span', 'ham']
+        data = [
+            ['1', '2'],
+            ['3', '4']
+        ]
+        expected = [
+            '.. list-table::',
+            '   :header-rows: 1',
+            '',
+            '   * - span',
+            '     - ham',
+            '   * - 1',
+            '     - 2',
+            '   * - 3',
+            '     - 4',
+            ''
+        ]
+        r.table_list(headers, data)
+        self.assertEqual(r.data, expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rstcloth.py
+++ b/tests/test_rstcloth.py
@@ -398,5 +398,62 @@ class TestRstCloth(BaseTestCase):
         self.assertIn("cannot set the RstCloth.data attribute directly", exception.exception.args)
 
 
+class TestTable(unittest.TestCase):
+    """Testing operation of the Rst generator"""
+
+    def test_header_1_body_0(self):
+        r = RstCloth()
+        r.table(header=('span',), data=None)
+        expected = "\n+-------+\n" \
+                   "|span   |\n" \
+                   "+=======+\n"
+        given = r.data[0]
+        self.assertEqual(expected, given)
+
+    def test_header_1_body_1(self):
+        r = RstCloth()
+        r.table(header=('span',), data=((1,),))
+        expected = "\n+-------+\n" \
+                   "|span   |\n" \
+                   "+=======+\n" \
+                   "|1      |\n" \
+                   "+-------+\n"
+        given = r.data[0]
+        self.assertEqual(expected, given)
+
+    def test_header_2_body_0(self):
+        r = RstCloth()
+        r.table(header=('span', 'ham'), data='')
+        expected = "\n+-------+------+\n" \
+                   "|span   |ham   |\n" \
+                   "+=======+======+\n"
+        given = r.data[0]
+        self.assertEqual(expected, given)
+
+    def test_header_2_body_1(self):
+        r = RstCloth()
+        r.table(header=('span', 'ham'), data=((1, 2),))
+        expected = "\n+-------+------+\n" \
+                   "|span   |ham   |\n" \
+                   "+=======+======+\n" \
+                   "|1      |2     |\n" \
+                   "+-------+------+\n"
+        given = r.data[0]
+        self.assertEqual(expected, given)
+
+    def test_header_2_body_2(self):
+        r = RstCloth()
+        r.table(header=('span', 'ham'), data=((1, 2), (3, 4)))
+        expected = "\n+-------+------+\n" \
+                   "|span   |ham   |\n" \
+                   "+=======+======+\n" \
+                   "|1      |2     |\n" \
+                   "+-------+------+\n" \
+                   "|3      |4     |\n" \
+                   "+-------+------+\n"
+        given = r.data[0]
+        self.assertEqual(expected, given)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rstcloth.py
+++ b/tests/test_rstcloth.py
@@ -404,53 +404,55 @@ class TestTable(unittest.TestCase):
     def test_header_1_body_0(self):
         r = RstCloth()
         r.table(header=('span',), data=None)
-        expected = "\n+-------+\n" \
-                   "|span   |\n" \
-                   "+=======+\n"
+        expected = "\n+--------+\n" \
+                   "| span   |\n" \
+                   "+========+\n" \
+                   "+--------+\n"
         given = r.data[0]
         self.assertEqual(expected, given)
 
     def test_header_1_body_1(self):
         r = RstCloth()
         r.table(header=('span',), data=((1,),))
-        expected = "\n+-------+\n" \
-                   "|span   |\n" \
-                   "+=======+\n" \
-                   "|1      |\n" \
-                   "+-------+\n"
+        expected = "\n+--------+\n" \
+                   "| span   |\n" \
+                   "+========+\n" \
+                   "| 1      |\n" \
+                   "+--------+\n"
         given = r.data[0]
         self.assertEqual(expected, given)
 
     def test_header_2_body_0(self):
         r = RstCloth()
         r.table(header=('span', 'ham'), data='')
-        expected = "\n+-------+------+\n" \
-                   "|span   |ham   |\n" \
-                   "+=======+======+\n"
+        expected = "\n+--------+-------+\n" \
+                   "| span   | ham   |\n" \
+                   "+========+=======+\n" \
+                   "+--------+-------+\n"
         given = r.data[0]
         self.assertEqual(expected, given)
 
     def test_header_2_body_1(self):
         r = RstCloth()
         r.table(header=('span', 'ham'), data=((1, 2),))
-        expected = "\n+-------+------+\n" \
-                   "|span   |ham   |\n" \
-                   "+=======+======+\n" \
-                   "|1      |2     |\n" \
-                   "+-------+------+\n"
+        expected = "\n+--------+-------+\n" \
+                   "| span   | ham   |\n" \
+                   "+========+=======+\n" \
+                   "| 1      | 2     |\n" \
+                   "+--------+-------+\n"
         given = r.data[0]
         self.assertEqual(expected, given)
 
     def test_header_2_body_2(self):
         r = RstCloth()
         r.table(header=('span', 'ham'), data=((1, 2), (3, 4)))
-        expected = "\n+-------+------+\n" \
-                   "|span   |ham   |\n" \
-                   "+=======+======+\n" \
-                   "|1      |2     |\n" \
-                   "+-------+------+\n" \
-                   "|3      |4     |\n" \
-                   "+-------+------+\n"
+        expected = "\n+--------+-------+\n" \
+                   "| span   | ham   |\n" \
+                   "+========+=======+\n" \
+                   "| 1      | 2     |\n" \
+                   "+--------+-------+\n" \
+                   "| 3      | 4     |\n" \
+                   "+--------+-------+\n"
         given = r.data[0]
         self.assertEqual(expected, given)
 


### PR DESCRIPTION
Hi,

This Pull Request is aimed to address "crumminess" of table handling mentioned in #9 and to add support for list-table directive.

Commit 1f2a030 introduces definitely non-exhaustive table testing just to illustrate what changes with switch to python-tabulate.

For next steps I would like to suggest:
1. drop rstcloth.rstcloth.Table class
It's no longer used in rstcloth and maintaining multiple table formatting code might be a headache. If we decide to switch to python-tabulate then we should keep consistent.

2. drop whole rstcloth.table module
As it is mainly for transforming input YAML table into grid, list and HTML table. Currently only HTML format is not supported by RstCloth class. My reasoning here is the same as above: maintainability and consistency.

Those points are too big for a tiny PR like this but even small change might inspire bigger one :wink:.

Happy New Year!