### PR TITLE
Alter print methods to use __str__

### DIFF
--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -22,7 +22,7 @@ The following RstCloth code: ::
    d.h2('Code -- shebang')
    d.codeblock('#!/usr/bin/env')
 
-   d.print_content()
+   print(str(d))
 
 Would result in the following reStructuredText: ::
 
@@ -61,5 +61,22 @@ Example 2
         ]
     )
 
-    doc.print_content()
+    print(str(doc))
+
+Would result in the following reStructuredText: ::
+
+    ================
+    Example Document
+    ================
+
+
+    +-----------+-----------+-----------+
+    |Column 1   |Column 2   |Column 3   |
+    +===========+===========+===========+
+    |1          |2          |3          |
+    +-----------+-----------+-----------+
+    |4          |5          |6          |
+    +-----------+-----------+-----------+
+    |7          |8          |9          |
+    +-----------+-----------+-----------+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rstcloth"
-version = "0.3.2"
+version = "0.4.0"
 description = "A simple Python API for generating RestructuredText."
 authors = ["Tom Clark"]
 license = "MIT"

--- a/rstcloth/cloth.py
+++ b/rstcloth/cloth.py
@@ -6,8 +6,8 @@ logger = logging.getLogger("rstcloth.cloth")
 
 
 class Cloth(object):
-    def print_content(self):
-        print("\n".join(self._data))  # noqa: T001
+    def __str__(self):
+        return "\n".join(self._data)
 
     def write(self, filename):
         """

--- a/rstcloth/table.py
+++ b/rstcloth/table.py
@@ -413,9 +413,8 @@ class TableBuilder(object):
             for line in self.output:
                 f.write(line + "\n")
 
-    def print_table(self):
-        for line in self.output:
-            print(line)  # noqa: T001
+    def __str__(self):
+        return "\n".join(self.output)
 
 
 ###################################


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#25](https://github.com/thclark/rstcloth/pull/25))

### New features
- Increment version for new __str__ methods

### Uncategorised!
- replace print_content and print_table methods with __str__
- fix table __str__
- Merge pull request #16 from sp1thas/fix/replace-print-content-with-str-method

<!--- END AUTOGENERATED NOTES --->