### PR TITLE
OPS: Widen python requirement to prevent prohibitive installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rstcloth"
-version = "0.5.6"
+version = "0.5.7"
 description = "A simple Python API for generating RestructuredText."
 authors = ["Tom Clark"]
 license = "MIT"
@@ -12,6 +12,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
     "Natural Language :: English",
     "Topic :: Documentation :: Sphinx",
@@ -21,22 +23,29 @@ classifiers = [
     "Topic :: Utilities",
 ]
 repository = "https://github.com/thclark/rstcloth"
-keywords = ["sphinx", "rst", "restructuredtext", "documentation", "rest", "docutils"]
-packages = [{ include = "rstcloth" },]
+keywords = [
+    "sphinx",
+    "rst",
+    "restructuredtext",
+    "documentation",
+    "rest",
+    "docutils",
+]
+packages = [{ include = "rstcloth" }]
 
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.12"
+python = ">=3.7,<4"
 Pygments = "^2.12.0"
 PyYAML = ">=5,<7"
 # These are here as extras to allow them to be installed as extras
 # Strictly they're dev-dependencies but they don't get installed that way
 # (see https://github.com/python-poetry/poetry/issues/3348)
-sphinx = {version = ">=2,<8", optional = true}
-sphinx-rtd-theme = {version = "1.0.0", optional = true}
-sphinx-tabs = {version = "3.2.0", optional = true}
-sphinx-charts = {version = "0.1.2", optional = true}
-sphinx-math-dollar = {version = "1.2.0", optional = true}
+sphinx = { version = ">=2,<8", optional = true }
+sphinx-rtd-theme = { version = "1.0.0", optional = true }
+sphinx-tabs = { version = "3.2.0", optional = true }
+sphinx-charts = { version = "0.1.2", optional = true }
+sphinx-math-dollar = { version = "1.2.0", optional = true }
 tabulate = ">=0.8.9,<0.10"
 
 [tool.poetry.dev-dependencies]
@@ -49,7 +58,13 @@ pytest = "^6.2.5"
 # tox-poetry = "^0.4.1"
 
 [tool.poetry.extras]
-docs = ["sphinx", "sphinx-rtd-theme", "sphinx-tabs", "sphinx-charts", "sphinx-math-dollar"]
+docs = [
+    "sphinx",
+    "sphinx-rtd-theme",
+    "sphinx-tabs",
+    "sphinx-charts",
+    "sphinx-math-dollar",
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#51](https://github.com/thclark/rstcloth/pull/51))

### Operations
- Widen python requirement to prevent prohibitive installs

<!--- END AUTOGENERATED NOTES --->